### PR TITLE
Add transcript cleanup script + upload cleanup on error

### DIFF
--- a/lib/aws.py
+++ b/lib/aws.py
@@ -8,6 +8,12 @@ s3_put_file(local_path, bucket, key, secrets, **kwargs)
 ========================================================================================================================
 get_s3_url(bucket, key)
     Get S3 url for bucket and key pair
+========================================================================================================================
+s3_list_objects(bucket, secrets, **kwargs)
+    List all keys in a given bucket
+========================================================================================================================
+s3_delete_key(bucket, key, secrets, **kwargs)
+    Delete a given key
 """
 
 import os
@@ -81,3 +87,44 @@ def get_s3_url(bucket,
     """
 
     return 'https://%s.s3.amazonaws.com/%s' % (bucket, key)
+
+
+def s3_list_objects(bucket,
+                    secrets,
+                    **kwargs):
+    """
+    List all keys in a given bucket
+
+    :param bucket: (str) bucket name in S3
+    :param secrets: (dict) Result from helpers.get_secrets
+    :param kwargs: kwargs for boto3.client
+    :return: (list of dicts) dict per key
+    """
+
+    kwargs = manage_kwargs(kwargs, secrets)
+    client = boto3.client('s3', **kwargs)
+
+    res = client.list_objects_v2(Bucket=bucket)
+
+    return res.get('Contents', [])
+
+
+def s3_delete_key(bucket,
+                  key,
+                  secrets,
+                  **kwargs):
+    """
+    Delete a given key
+
+    :param bucket: (str) bucket name in S3
+    :param key: (str) full destination path including file name
+    :param secrets: (dict) Result from helpers.get_secrets
+    :param kwargs: kwargs for boto3.client
+    """
+
+    kwargs = manage_kwargs(kwargs, secrets)
+    resource = boto3.resource('s3', **kwargs)
+
+    resource.Object(bucket, key).delete()
+
+    LOG.info('Deleted from S3 - %s/%s', bucket, key)

--- a/lib/mongo.py
+++ b/lib/mongo.py
@@ -80,7 +80,7 @@ def put_to_mongo(dbname,
     :param coll: (str) mongo collection
     :param doc: (dict) doc as dict
     :param secrets: (dict) Result from helpers.get_secrets
-    :return: (pymongo.results.InsertOneResult) Mongo response
+    :return: (bson.objectid.ObjectId) mongo OID
     """
 
     conn = get_coll_conn(dbname, coll, secrets)

--- a/lib/mongo.py
+++ b/lib/mongo.py
@@ -28,6 +28,9 @@ auth_user(dbname, coll, auth_dict, token_handler, secrets)
 ========================================================================================================================
 stt_json_to_mongo_frmt(doc, stt_json)
     Converts STT JSON to MONGO formatted doc
+========================================================================================================================
+delete_from_mongo(dbname, coll, id, secrets)
+    Delete doc from mongo
 """
 
 import os
@@ -227,3 +230,25 @@ def stt_json_to_mongo_frmt(doc,
     doc['transcript'] = transcript
 
     return doc
+
+
+def delete_from_mongo(dbname,
+                      coll,
+                      id,
+                      secrets):
+    """
+    Delete doc from mongo
+
+    :param dbname: (str) mongo dbname
+    :param coll: (str) mongo collection
+    :param id: (bson.objectid.ObjectId) mongo OID
+    :param secrets: (dict) Result from helpers.get_secrets
+    :return: (pymongo.results.InsertOneResult) Mongo response
+    """
+
+    conn = get_coll_conn(dbname, coll, secrets)
+    res = conn.delete_one({'_id': id})
+
+    LOG.info('Deleted doc - %s - %s - %s', dbname, coll, id)
+
+    return res

--- a/ops/transcript_cleanup.py
+++ b/ops/transcript_cleanup.py
@@ -1,0 +1,40 @@
+"""
+Deletes transcript docs that failed to transcribe.
+Will only delete files with a certain age
+defined by HOURS_AGO_CREATED_TRESHOLD that can be changed
+"""
+
+import os
+import sys
+
+REPO_DIRECTORY = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(REPO_DIRECTORY)
+
+from datetime import datetime, \
+                     timedelta
+import pytz
+from lib.helpers import get_secrets
+from lib.mongo import search_mongo
+from sw_app.DeleteTranscript import DeleteTranscript
+import config
+
+
+HOURS_AGO_CREATED_TRESHOLD = 2
+SECRETS = get_secrets()
+
+
+mongo_ids = search_mongo(config.MONGO_DBNAME,
+                         config.TRANSCRIPTS_COLL,
+                         {'transcribe_complete':False},
+                         SECRETS,
+                         {'_id':1})
+
+mongo_ids = [id['_id'] for id in mongo_ids]
+
+for id in mongo_ids:
+    id_time = id.generation_time
+    utcnow = datetime.utcnow().replace(tzinfo=pytz.UTC)
+    time_diff = utcnow - id_time
+
+    if time_diff >= timedelta(hours=HOURS_AGO_CREATED_TRESHOLD):
+        DeleteTranscript(str(id), SECRETS).delete()

--- a/sw_app/DeleteTranscript.py
+++ b/sw_app/DeleteTranscript.py
@@ -1,0 +1,68 @@
+import os
+import sys
+
+REPO_DIRECTORY = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(REPO_DIRECTORY)
+
+from bson.objectid import ObjectId
+from lib.mongo import delete_from_mongo
+from lib.aws import s3_list_objects, \
+                    s3_delete_key
+from config import MONGO_DBNAME, \
+                   TRANSCRIPTS_COLL, \
+                   S3_BUCKET
+
+
+class DeleteTranscript:
+    """
+    Class for Deleting Transcipts
+
+    Methods
+    -------
+    delete()
+        Delete doc from Mongo and the correlating S3 files
+    """
+
+    def __init__(self,
+                 id,
+                 secrets,
+                 s3_bucket=S3_BUCKET,
+                 mongo_dbname=MONGO_DBNAME,
+                 mongo_coll=TRANSCRIPTS_COLL):
+        """
+        Init DeleteTranscript
+
+        :param id: (str) mongo OID
+        :param secrets: (dict) Result from helpers.get_secrets
+        :param s3_bucket: (str) S3 bucket that files will be uploaded to
+        :param mongo_dbname: (str) Mongo dbname to insert docs to
+        :param mongo_coll: (str) Mongo collection to insert docs to
+        """
+
+        self.id = id
+        self.secrets = secrets
+        self.s3_bucket = s3_bucket
+        self.mongo_dbname = mongo_dbname
+        self.mongo_coll = mongo_coll
+
+
+    def delete(self):
+        """
+        Delete doc from Mongo and the correlating S3 files
+        """
+
+        keys = s3_list_objects(self.s3_bucket,
+                               self.secrets)
+
+        for key_data in keys:
+            key = key_data.get('Key', '')
+            if self.id in key:
+                s3_delete_key(self.s3_bucket,
+                              key,
+                              self.secrets)
+                continue
+
+        delete_from_mongo(self.mongo_dbname,
+                          self.mongo_coll,
+                          ObjectId(self.id),
+                          self.secrets)

--- a/sw_app/Transcribe.py
+++ b/sw_app/Transcribe.py
@@ -81,18 +81,24 @@ class Transcribe:
         Run transcription process
         """
 
-        self.log = getLog('Transcribe - %s' % self.path)
-        self.log.info('Start')
+        try:
+            self.log = getLog('Transcribe - %s' % self.path)
+            self.log.info('Start')
 
-        self._set_mongo_oid()
-        self._thumbnail_extract_and_upload()
-        self._flac_conv_and_upload()
-        self._handle_stt()
-        self._org_upload()
-        self._handle_mongo()
-        self._clean_up()
+            self._set_mongo_oid()
+            self._thumbnail_extract_and_upload()
+            self._flac_conv_and_upload()
+            self._handle_stt()
+            self._org_upload()
+            self._handle_mongo()
+            self._clean_up()
 
-        self.log.info('Done')
+            self.log.info('Done')
+
+        except Exception as e:
+            self.log.error(str(e))
+            self._clean_up()
+            raise
 
 
     def run_async(self):

--- a/sw_app/Transcribe.py
+++ b/sw_app/Transcribe.py
@@ -113,7 +113,7 @@ class Transcribe:
         When performing cleanups we will be able to see docs
         that are marked as False and delete \ investigate all their responding files
 
-        :set attr: mongo_oid (str) OID of created Mongo Doc
+        :set attr: mongo_oid (bson.objectid.ObjectId) mongo OID of created doc
         """
 
         res = put_to_mongo(self.mongo_dbname,


### PR DESCRIPTION
1. Added `DeleteTranscript` for deleting transcripts from Mongo and their correlating files in S3.
2. Added cleanup on error in the transcript upload process
3. Added `ops` folder with `transcript_cleanup.py` for deleting leftover docs and correlating S3 files. This should be avoided now that we cleanup on error in the upload process, but it's not bad for us to have this script :)