### PR TITLE
Change Google Creds path and changed perms to fix SSH access issue

### DIFF
--- a/.ebextensions/soulwings.config
+++ b/.ebextensions/soulwings.config
@@ -4,7 +4,7 @@ option_settings:
   "aws:elasticbeanstalk:container:python:staticfiles":
     "static": "static/"
   "aws:elasticbeanstalk:application:environment":
-    GOOGLE_APPLICATION_CREDENTIALS: "/home/ec2-user/soulwings-94e1c45b141d.json"
+    GOOGLE_APPLICATION_CREDENTIALS: "/soulwings-94e1c45b141d.json"
   aws:elb:listener:443:
     SSLCertificateId: arn:aws:acm:us-east-1:522352883303:certificate/482c81cf-79fb-456f-afc0-5928122c7845
     ListenerProtocol: HTTPS
@@ -13,4 +13,4 @@ commands:
   install_ffmpeg:
     command: "mkdir install_ffmpeg && cd install_ffmpeg && wget https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-amd64-static.tar.xz && mkdir ffmpeg_unpacked && tar xvf ffmpeg-git-amd64-static.tar.xz -C ffmpeg_unpacked --strip-components 1 && sudo mv ffmpeg_unpacked/ffmpeg ffmpeg_unpacked/ffprobe /usr/local/bin/ && cd .. && rm -r install_ffmpeg/"
   get_google_secret:
-    command: "aws s3 cp s3://soul-wings-secrets/soulwings-94e1c45b141d.json /home/ec2-user/soulwings-94e1c45b141d.json && sudo chmod -R a+rwX /home/"
+    command: "aws s3 cp s3://soul-wings-secrets/soulwings-94e1c45b141d.json /soulwings-94e1c45b141d.json && sudo chmod a+rwX /soulwings-94e1c45b141d.json"


### PR DESCRIPTION
Changed Google Creds path and changed perms that the `chmod` after fetching it applies in order to avoid ruining perms in `/home/ec2-user/`.
The chmod caused SSH not to work, this fixes that so the server is accessible via SSH.