### PR TITLE
Change GCS upload and delete logic + Remove debug prints

### DIFF
--- a/lib/gc.py
+++ b/lib/gc.py
@@ -104,13 +104,10 @@ def stt_res_to_json(res,
     """
 
     serialized = MessageToDict(res)
-    print('serialized', sys.getsizeof(serialized))
     serialized['user_fields'] = user_fields
 
     json_file = codecs.open(path, 'w', encoding='utf-8')
-    print('json dump start')
     json.dump(serialized, json_file, ensure_ascii=False)
-    print('json dump done')
     json_file.close()
 
     LOG.info('Saved JSON - %s', path)

--- a/lib/gc.py
+++ b/lib/gc.py
@@ -3,6 +3,9 @@ This Module contains Google Cloud helper functions:
 gcs_put_file(local_path, gcs_bucket, gcs_path)
     Upload a given file to GCS and return blob obj
 ========================================================================================================================
+gcs_del_file(gcs_bucket, gcs_path)
+    Delete a given file from GCS
+========================================================================================================================
 call_stt(gcs_bucket, gcs_path)
     Call Google STT and get transcript for given GCS path
 ========================================================================================================================
@@ -35,12 +38,11 @@ def gcs_put_file(local_path,
                  gcs_bucket,
                  gcs_path):
     """
-    Upload a given file to GCS and return blob obj
+    Upload a given file to GCS
 
     :param local_path: (str) local path of file to upload
     :param gcs_bucket: (str) GCS bucket name
     :param gcs_path: (str) Path in bucket to upload to
-    :return: (bucket.blob) gcs file obj
     """
 
     storage_client = storage.Client()
@@ -50,7 +52,21 @@ def gcs_put_file(local_path,
 
     LOG.info('Put to GCS - %s - %s/%s', local_path, gcs_bucket, gcs_path)
 
-    return blob
+
+def gcs_del_file(gcs_bucket,
+                 gcs_path):
+    """
+    Delete a given file from GCS
+
+    :param gcs_bucket: (str) GCS bucket name
+    :param gcs_path: (str) Path in bucket to delete file from
+    """
+
+    storage_client = storage.Client()
+    bucket = storage_client.get_bucket(gcs_bucket)
+    blob = bucket.delete_blob(gcs_path)
+
+    LOG.info('Deleted from GCS - %s/%s', gcs_bucket, gcs_path)
 
 
 def call_stt(gcs_bucket,

--- a/sw_app/Transcribe.py
+++ b/sw_app/Transcribe.py
@@ -197,8 +197,6 @@ class Transcribe:
         res = call_stt(self.gcs_bucket,
                        flac_file_name,
                        self.language)
-        print('self.gcs_blob', sys.getsizeof(self.gcs_blob))              
-        print('res', sys.getsizeof(res))
         self.gcs_blob.delete()
 
         self.json_path = os.path.splitext(self.path)[0] + '.json'


### PR DESCRIPTION
1. Seems like the fact that we were saving `self.gcs_blob` was causing memory issues.
Now the server will save the `gcs_path` and delete the file with the new func `gcs_del_file`.

2. Removed debug prints from this commit https://github.com/soul-wings/soul-wings/commit/941a0ed3eff5c5d08ceac6098565d1d93e89e2c4